### PR TITLE
Fix #2 - Mobile browsers are unable to detect if the entire page is scrollable

### DIFF
--- a/src/css/logo.css
+++ b/src/css/logo.css
@@ -11,6 +11,10 @@
     pointer-events: none;
 }
 
+.crocodoc-window-as-viewport .crocodoc-viewer-logo {
+    position: fixed;
+}
+
 /* hidpi logo */
 @media only screen and (-webkit-min-device-pixel-ratio: 2) {
     .crocodoc-viewer-logo {

--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -26,7 +26,6 @@
     -webkit-transform: translateZ(0);
     transform: translateZ(0);
 }
-
 .crocodoc-draggable .crocodoc-viewport {
     cursor: move;
     cursor: -webkit-grab;
@@ -48,6 +47,19 @@
     position: relative;
     -webkit-transform: translateZ(0);
     transform: translateZ(0);
+}
+
+.crocodoc-window-as-viewport .crocodoc-viewport {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    overflow: visible;
+}
+
+.crocodoc-window-as-viewport .crocodoc-doc {
+    width: auto;
+    height: auto;
+    overflow: visible;
 }
 
 /* wrapper around all pages, gets css transforms for zoom */

--- a/src/js/components/layout-base.js
+++ b/src/js/components/layout-base.js
@@ -153,7 +153,14 @@ Crocodoc.addComponent('layout-base', function (scope) {
          * @returns {void}
          */
         initState: function () {
-            var viewportEl = this.$viewport[0];
+            var viewportEl = this.$viewport[0],
+                dimensionsEl = viewportEl;
+
+            // use the documentElement for viewport dimensions
+            // if we are using the window as the viewport
+            if (viewportEl === window) {
+                dimensionsEl = document.documentElement;
+            }
             // setup initial state
             this.state = {
                 pages: [],
@@ -171,10 +178,10 @@ Crocodoc.addComponent('layout-base', function (scope) {
                 scrollTop: viewportEl.scrollTop,
                 scrollLeft: viewportEl.scrollLeft,
                 viewportDimensions: {
-                    clientWidth: viewportEl.clientWidth,
-                    clientHeight: viewportEl.clientHeight,
-                    offsetWidth: viewportEl.offsetWidth,
-                    offsetHeight: viewportEl.offsetHeight
+                    clientWidth: dimensionsEl.clientWidth,
+                    clientHeight: dimensionsEl.clientHeight,
+                    offsetWidth: dimensionsEl.offsetWidth,
+                    offsetHeight: dimensionsEl.offsetHeight
                 },
                 zoomState: {
                     zoom: 1,

--- a/src/js/components/resizer.js
+++ b/src/js/components/resizer.js
@@ -20,7 +20,9 @@ Crocodoc.addComponent('resizer', function (scope) {
         // @NOTE: IE 11 uses upper-camel-case for this, which is apparently necessary
         'MSFullscreenChange';
 
-    var element,
+    var $window = $(window),
+        $document = $(document),
+        element,
         currentClientWidth,
         currentClientHeight,
         currentOffsetWidth,
@@ -86,8 +88,21 @@ Crocodoc.addComponent('resizer', function (scope) {
          */
         init: function (el) {
             element = $(el).get(0);
-           $(document).on(FULLSCREENCHANGE_EVENT, broadcast);
-            loop();
+
+            // use the documentElement for viewport dimensions
+            // if we are using the window as the viewport
+            if (element === window) {
+                element = document.documentElement;
+                $window.on('resize', checkResize);
+                // @NOTE: we don't need to loop with
+                // requestAnimationFrame in this case,
+                // because we can rely on window.resize
+                // events if the window is our viewport
+                checkResize();
+            } else {
+                loop();
+            }
+           $document.on(FULLSCREENCHANGE_EVENT, broadcast);
         },
 
         /**
@@ -95,7 +110,8 @@ Crocodoc.addComponent('resizer', function (scope) {
          * @returns {void}
          */
         destroy: function () {
-           $(document).off(FULLSCREENCHANGE_EVENT, broadcast);
+            $document.off(FULLSCREENCHANGE_EVENT, broadcast);
+            $window.off('resize', checkResize);
             support.cancelAnimationFrame(resizeFrameID);
         }
     };

--- a/src/js/components/viewer-base.js
+++ b/src/js/components/viewer-base.js
@@ -24,6 +24,7 @@ Crocodoc.addComponent('viewer-base', function (scope) {
         CSS_CLASS_MOBILE         = CSS_CLASS_PREFIX + 'mobile',
         CSS_CLASS_IELT9          = CSS_CLASS_PREFIX + 'ielt9',
         CSS_CLASS_SUPPORTS_SVG   = CSS_CLASS_PREFIX + 'supports-svg',
+        CSS_CLASS_WINDOW_AS_VIEWPORT = CSS_CLASS_PREFIX + 'window-as-viewport',
         CSS_CLASS_PAGE           = CSS_CLASS_PREFIX + 'page',
         CSS_CLASS_PAGE_INNER     = CSS_CLASS_PAGE + '-inner',
         CSS_CLASS_PAGE_CONTENT   = CSS_CLASS_PAGE + '-content',
@@ -128,9 +129,14 @@ Crocodoc.addComponent('viewer-base', function (scope) {
     function initViewerHTML() {
         // create viewer HTML
         $el.html(VIEWER_HTML_TEMPLATE);
-        config.$viewport = $el.find('.'+CSS_CLASS_VIEWPORT);
-        config.$doc = $el.find('.'+CSS_CLASS_DOC);
-        config.$pagesWrapper = $el.find('.'+CSS_CLASS_PAGES);
+        if (config.useWindowAsViewport) {
+            config.$viewport = $(window);
+            $el.addClass(CSS_CLASS_WINDOW_AS_VIEWPORT);
+        } else {
+            config.$viewport = $el.find('.' + CSS_CLASS_VIEWPORT);
+        }
+        config.$doc = $el.find('.' + CSS_CLASS_DOC);
+        config.$pagesWrapper = $el.find('.' + CSS_CLASS_PAGES);
     }
 
     /**

--- a/src/js/core/viewer.js
+++ b/src/js/core/viewer.js
@@ -299,6 +299,9 @@
         // enable/disable links layer
         enableLinks: true,
 
+        // enable/disable click-and-drag
+        enableDragging: false,
+
         // query string parameters to append to all asset requests
         queryParams: null,
 
@@ -313,8 +316,10 @@
         // USE AT YOUR OWN RISK!
         //--------------------------------------------------------------------------
 
-        // enable/disable click-and-drag
-        enableDragging: false,
+        // whether to use the browser window as the viewport into the document (this
+        // is useful when the document should take up the entire browser window, e.g.,
+        // on mobile devices)
+        useWindowAsViewport: false,
 
         // whether or not the conversion is finished (eg., pages are ready to be loaded)
         conversionIsComplete: true,


### PR DESCRIPTION
Adds useWindowAsViewport config option to allow the document to stretch
the containing element to its full size and use the window as its
viewport instead of using overflow:scroll on the viewport element.
This allows mobile browsers to hide browser chrome and jump back to
the top natively.
