### PR TITLE
Simplify DOM structure

### DIFF
--- a/src/css/carousel.css
+++ b/src/css/carousel.css
@@ -1,16 +1,12 @@
 /***** CAROUSEL STUFF *****/
 
-.crocodoc-carousel .crocodoc-doc,
-.crocodoc-carousel .crocodoc-pages {
+.crocodoc-carousel .crocodoc-doc {
     background: transparent;
-}
-
-.crocodoc-carousel .crocodoc-pages {
     overflow: visible;
     -webkit-perspective: 500px;
     perspective: 500px;
-    -webkit-perspective-origin: 100% 50%;
-    perspective-origin: 100% 50%;
+    -webkit-perspective-origin: 50% 50%;
+    perspective-origin: 50% 50%;
     -webkit-transform-style: preserve-3d;
     transform-style: preserve-3d;
 }

--- a/src/css/pageflip.css
+++ b/src/css/pageflip.css
@@ -21,7 +21,7 @@
     z-index: 1;
 }
 
-.crocodoc-pageflip .crocodoc-pages {
+.crocodoc-pageflip .crocodoc-doc {
     overflow: visible;
     -webkit-perspective: 2000px;
     perspective: 2000px;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -1,7 +1,7 @@
 /* Default Theme -------------------------------- */
 
 /* Background */
-.crocodoc-doc {
+.crocodoc-viewport {
     background: transparent;
 }
 

--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -40,11 +40,13 @@
 
 /* outside wrapper for positioning the transformed inner wrapper properly */
 .crocodoc-doc {
-    width: 100%;
-    height: 100%;
     overflow: hidden;
     /* @NOTE: position:relative is necessary for overflow:hidden to work in IE7 */
     position: relative;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    text-align: center;
+    font-size: 100%;
     -webkit-transform: translateZ(0);
     transform: translateZ(0);
 }
@@ -60,20 +62,6 @@
     width: auto;
     height: auto;
     overflow: visible;
-}
-
-/* wrapper around all pages, gets css transforms for zoom */
-.crocodoc-pages {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    text-align: center;
-    font-size: 100%;
-    overflow: hidden;
-    -webkit-transform-origin: 0 0;
-    -moz-transform-origin: 0 0;
-    -ms-transform-origin: 0 0;
-    transform-origin: 0 0;
 }
 
 /* individual pages */
@@ -217,7 +205,7 @@
 }
 
 /* Layout-specific styles -------------------------------- */
-.crocodoc-layout-horizontal .crocodoc-pages {
+.crocodoc-layout-horizontal .crocodoc-doc {
     text-align: left;
     white-space: nowrap;
 }
@@ -234,8 +222,8 @@
     display: block;
 }
 
-.crocodoc-layout-presentation-two-page .crocodoc-pages,
-.crocodoc-layout-presentation .crocodoc-pages {
+.crocodoc-layout-presentation-two-page .crocodoc-doc,
+.crocodoc-layout-presentation .crocodoc-doc {
     overflow: visible;
     /* @NOTE: this is for IE 7; text-align is incorrectly honored even when pages are position:absolute/display:block */
     text-align: left;

--- a/src/js/components/layout-base.js
+++ b/src/js/components/layout-base.js
@@ -140,7 +140,6 @@ Crocodoc.addComponent('layout-base', function (scope) {
             this.$doc = config.$doc;
             this.$viewport = config.$viewport;
             this.$pages = config.$pages;
-            this.$pagesWrapper = config.$pagesWrapper;
             this.numPages = config.numPages;
 
             // add the layout css class
@@ -206,7 +205,7 @@ Crocodoc.addComponent('layout-base', function (scope) {
          * @returns {void}
          */
         destroy: function () {
-            this.$pagesWrapper.add(this.$doc).removeAttr('style');
+            this.$doc.removeAttr('style');
             this.$pages.css('padding', '');
             this.$el.removeClass(this.layoutClass);
         },
@@ -817,7 +816,7 @@ Crocodoc.addComponent('layout-base', function (scope) {
          */
         handleScrollEnd: function (data) {
             // update CSS classes
-            this.$pagesWrapper.find('.' + CSS_CLASS_CURRENT_PAGE).removeClass(CSS_CLASS_CURRENT_PAGE);
+            this.$doc.find('.' + CSS_CLASS_CURRENT_PAGE).removeClass(CSS_CLASS_CURRENT_PAGE);
             this.$pages.eq(this.state.currentPage - 1).addClass(CSS_CLASS_CURRENT_PAGE);
             this.updateVisiblePages(true);
             this.handleScroll(data);

--- a/src/js/components/layout-horizontal.js
+++ b/src/js/components/layout-horizontal.js
@@ -112,13 +112,9 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_HORIZONTAL, ['layout-base'], f
                 docWidth = Math.max(zoomedWidth, state.viewportDimensions.clientWidth),
                 docHeight = Math.max(zoomedHeight, state.viewportDimensions.clientHeight);
 
-            this.$pagesWrapper.css({
-                height: docHeight,
-                lineHeight: docHeight + 'px',
-                width: docWidth
-            });
             this.$doc.css({
                 height: docHeight,
+                lineHeight: docHeight + 'px',
                 width: docWidth
             });
         }

--- a/src/js/components/layout-presentation.js
+++ b/src/js/components/layout-presentation.js
@@ -119,7 +119,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_PRESENTATION, ['layout-base'],
             var index = util.clamp(page - 1, 0, this.numPages);
             base.setCurrentPage.call(this, page);
             // update CSS classes
-            this.$pagesWrapper.find('.' + CSS_CLASS_CURRENT_PAGE).removeClass(CSS_CLASS_CURRENT_PAGE);
+            this.$doc.find('.' + CSS_CLASS_CURRENT_PAGE).removeClass(CSS_CLASS_CURRENT_PAGE);
             this.$pages.eq(this.state.currentPage - 1).addClass(CSS_CLASS_CURRENT_PAGE);
             this.updateVisiblePages(true);
             this.updatePageClasses(index);
@@ -164,7 +164,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_PRESENTATION, ['layout-base'],
             docWidth = Math.max(zoomedWidth, viewportWidth);
             docHeight = Math.max(zoomedHeight, viewportHeight);
 
-            this.$pagesWrapper.add(this.$doc).css({
+            this.$doc.css({
                 width: docWidth,
                 height: docHeight
             });

--- a/src/js/components/layout-vertical.js
+++ b/src/js/components/layout-vertical.js
@@ -127,20 +127,9 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_VERTICAL, ['layout-base'], fun
             var state = this.state,
                 zoom = state.zoomState.zoom,
                 zoomedWidth,
-                docWidth,
-                docHeight,
-                wrapWidth,
-                wrapHeight;
+                docWidth;
 
             zoomedWidth = Math.floor(state.widestPage.totalActualWidth * zoom);
-            wrapWidth = Math.max(zoomedWidth, state.viewportDimensions.clientWidth);
-            wrapHeight = this.$pagesWrapper.height();
-
-            this.$pagesWrapper.css({
-                height: 'auto',
-                width: wrapWidth
-            });
-            wrapHeight = this.$pagesWrapper.height();
 
             // use clientWidth for the doc (prevent scrollbar)
             // use width:auto when possible
@@ -150,10 +139,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_VERTICAL, ['layout-base'], fun
                 docWidth = zoomedWidth;
             }
 
-            docHeight = wrapHeight;
-
             this.$doc.css({
-                height: docHeight,
                 width: docWidth
             });
         }

--- a/src/js/components/resizer.js
+++ b/src/js/components/resizer.js
@@ -81,6 +81,22 @@ Crocodoc.addComponent('resizer', function (scope) {
     }
 
     return {
+
+        messages: ['layoutchange'],
+
+        /**
+         * Handle framework messages
+         * @returns {void}
+         */
+        onmessage: function () {
+            // force trigger resize when layout changes
+            // @NOTE: we do this because the clientWidth/Height
+            // could be different based on the layout (and whether
+            // or not the new layout changes scrollbars)
+            currentOffsetHeight = null;
+            checkResize();
+        },
+
         /**
          * Initialize the Resizer component with an element to watch
          * @param  {HTMLElement} el The element to watch

--- a/test/js/components/layout-base-test.js
+++ b/test/js/components/layout-base-test.js
@@ -8,8 +8,7 @@ module('Component - layout-base', {
         this.config = {
             $el: $(),
             $viewport: $('<div>'),
-            $doc: $(),
-            $pagesWrapper: $('<div>'),
+            $doc: $('<div>'),
             $pages: $(),
             page: 1,
             currentPage: 1,
@@ -24,9 +23,9 @@ module('Component - layout-base', {
         this.scope = Crocodoc.getScopeForTest(this);
 
         for (var i = 0; i < 10; i++) {
-            this.config.$pagesWrapper.append('<div class="crocodoc-page"></div>');
+            this.config.$doc.append('<div class="crocodoc-page"></div>');
         }
-        this.config.$pages = this.config.$pagesWrapper.find('.crocodoc-page');
+        this.config.$pages = this.config.$doc.find('.crocodoc-page');
         this.component = Crocodoc.getComponentForTest('layout-base', this.scope);
     }
 });
@@ -287,7 +286,7 @@ test('handleScrollEnd() should update the current page when called', function ()
     var currentPage = 3;
     this.stub(this.component, 'updateVisiblePages');
     this.stub(this.component, 'handleScroll');
-    this.config.$pages = this.config.$pagesWrapper.find('.crocodoc-page');
+    this.config.$pages = this.config.$doc.find('.crocodoc-page');
     var $prevPage = this.config.$pages.eq(0).addClass(CSS_CLASS_CURRENT_PAGE);
     var $currentPage = this.config.$pages.eq(currentPage - 1);
     this.component.init(this.config);

--- a/test/js/components/resizer-test.js
+++ b/test/js/components/resizer-test.js
@@ -66,3 +66,17 @@ test('module should fire "resize" event with the proper data when element is res
     this.clock.tick(1);
     $el.remove();
 });
+
+test('onmessage() should trigger a resize message when called', function () {
+    var w = 100, h = 200,
+        data = {
+            width: w,
+            height: h
+        },
+        $el = $('<div>').css(data).appendTo(document.body);
+    this.component.init($el);
+    this.mock(this.scope)
+        .expects('broadcast')
+        .withArgs('resize', sinon.match(data));
+    this.component.onmessage('layoutchange');
+});

--- a/test/js/components/viewer-base-test.js
+++ b/test/js/components/viewer-base-test.js
@@ -291,6 +291,17 @@ test('setLayout() should not remove a previous layout or create a new one when c
     this.component.setLayout(Crocodoc.LAYOUT_VERTICAL);
 });
 
+test('setLayout() should broadcast a layoutchange message when called and the layout changes', function () {
+    this.component.init();
+
+    this.stub(this.scope,'createComponent').returns(this.components.layout);
+
+    this.mock(this.scope)
+        .expects('broadcast')
+        .withArgs('layoutchange', sinon.match.object);
+    this.component.setLayout(Crocodoc.LAYOUT_VERTICAL);
+});
+
 test('onmessage() should call fire() when called with all subscribed messages except scroll, afterscroll, and linkclicked', function () {
     this.component.init($('<div>'), { });
     var spy = this.spy(this.viewerAPI, 'fire');


### PR DESCRIPTION
Removes the `.crocodoc-pages` div wrapping the page elements. This
div was originally used for CSS transform-based zoom strategies,
but is no longer used, and ads unnecessary complexity to the code.
