### PR TITLE
Fix #22 - Images don't display in iOS 6.1

### DIFF
--- a/src/js/utilities/browser.js
+++ b/src/js/utilities/browser.js
@@ -7,6 +7,7 @@ Crocodoc.addUtility('browser', function () {
     'use strict';
 
     var ua = navigator.userAgent,
+        version,
         browser = {},
         ios, android, blackberry,
         webos, silk, ie;
@@ -20,12 +21,15 @@ Crocodoc.addUtility('browser', function () {
 
     if (ie) {
         browser.ie = true;
-        browser.version = parseFloat(/MSIE\s+(\d+\.\d+)/i.exec(ua)[1]);
+        version = /MSIE\s+(\d+\.\d+)/i.exec(ua);
+        browser.version = version && parseFloat(version[1]);
         browser.ielt9 = browser.version < 9;
         browser.ielt10 = browser.version < 10;
     }
     if (ios) {
         browser.ios = true;
+        version = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+        browser.version = version && parseFloat(version[1] + '.' + version[2]);
     }
     browser.mobile = /mobile/i.test(ua) || ios || android || blackberry || webos || silk;
     browser.firefox = /firefox/i.test(ua);


### PR DESCRIPTION
Fixes a bug in iOS 6.1 where `<use>` elements are not supported properly by replacing each `<use>` element with a clone of its referenced `<image>`.
