### PR TITLE
Fix ctrl+click on links in IE

### DIFF
--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -155,6 +155,12 @@
 .crocodoc-page-link {
     position: absolute;
     display: block;
+}
+/* Fix for IE ctrl+click behavior */
+.crocodoc-page-link span {
+    width: 100%;
+    height: 100%;
+    display: block;
     /* IE <= 9 requires a background image for an empty element to actually receive click events */
     background: url(data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==) 0 0 no-repeat;
 }

--- a/src/js/components/page-links.js
+++ b/src/js/components/page-links.js
@@ -16,7 +16,8 @@ Crocodoc.addComponent('page-links', function (scope) {
 
     var CSS_CLASS_PAGE_LINK = 'crocodoc-page-link';
 
-    var $el;
+    var $el,
+        browser = scope.getUtility('browser');
 
     /**
      * Create a link element given link data
@@ -29,12 +30,21 @@ Crocodoc.addComponent('page-links', function (scope) {
             left = link.bbox[0],
             top = link.bbox[1],
             attr = {};
+
+        if (browser.ie) {
+            // @NOTE: IE doesn't allow override of ctrl+click on anchor tags,
+            // but there is a workaround to add a child element (which triggers
+            // the onclick event first)
+            $link.append('<span>');
+        }
+
         $link.css({
             left: left + 'pt',
             top: top + 'pt',
             width: link.bbox[2] - left + 'pt',
             height: link.bbox[3] - top + 'pt'
         });
+
         if (link.uri) {
             if (/^http|^mailto/.test(link.uri)) {
                 attr.href = encodeURI(link.uri);
@@ -46,6 +56,7 @@ Crocodoc.addComponent('page-links', function (scope) {
         } else if (link.destination) {
             attr.href = '#page-' + link.destination.pagenum;
         }
+
         $link.attr(attr);
         $link.data('link', link);
         $link.appendTo($el);
@@ -53,17 +64,19 @@ Crocodoc.addComponent('page-links', function (scope) {
 
     /**
      * Handle link clicks
-     * @param   {Event} ev The event object
+     * @param   {Event} event The event object
      * @returns {void}
      * @private
      */
-    function handleClick(ev) {
-        var $link = $(ev.target),
+    function handleClick(event) {
+        var targetEl = browser.ie ? event.target.parentNode : event.target,
+            $link = $(targetEl),
             data = $link.data('link');
+
         if (data) {
             scope.broadcast('linkclick', data);
         }
-        ev.preventDefault();
+        event.preventDefault();
     }
 
     //--------------------------------------------------------------------------
@@ -79,7 +92,11 @@ Crocodoc.addComponent('page-links', function (scope) {
         init: function (el, links) {
             $el = $(el);
             this.createLinks(links);
-            $el.on('click', '.'+CSS_CLASS_PAGE_LINK, handleClick);
+            var clickTarget = '.' + CSS_CLASS_PAGE_LINK;
+            if (browser.ie) {
+                clickTarget += ' span';
+            }
+            $el.on('click', clickTarget, handleClick);
         },
 
         /**
@@ -88,6 +105,7 @@ Crocodoc.addComponent('page-links', function (scope) {
          */
         destroy: function () {
             $el.empty().off('click');
+            $el = browser = null;
         },
 
         /**

--- a/test/js/components/page-links-test.js
+++ b/test/js/components/page-links-test.js
@@ -3,12 +3,16 @@ module('Component - page-links', {
         this.links = [
             {bbox: [690.89, 45.87, 716.15, 63.55], uri: 'http://box.com/'}
         ];
+        this.browser = Crocodoc.getUtility('browser');
         this.scope = Crocodoc.getScopeForTest(this);
+        this.utilities = {
+            browser: this.browser
+        };
         this.component = Crocodoc.getComponentForTest('page-links', this.scope);
     }
 });
 
-test('init() should call createLinks() when called', function () {
+test('init() should create links when called', function () {
     var links = [];
     this.mock(this.component)
         .expects('createLinks')
@@ -16,10 +20,18 @@ test('init() should call createLinks() when called', function () {
     this.component.init($(), links);
 });
 
+test('init() should create links with a child span element for IE workaround when called', function () {
+    var $el = $('<div>');
+    this.browser.ie = true;
+    this.component.init($el, this.links);
+    ok($el.find('.crocodoc-page-link span').length > 0, 'span element should exist');
+});
+
 test('module should broadcast `linkclick` event with appropriate data when a link is clicked', function () {
     var $el = $('<div>'),
         linkData = this.links[0];
 
+    this.browser.ie = false;
     this.mock(this.scope)
         .expects('broadcast')
         .withArgs('linkclick', linkData);


### PR DESCRIPTION
In IE, ctrl+click on anchor tags cannot be caught (and default
prevented) by JavaScript. This means that ctrl+click will not be
caught and forwarded to the `linkclick` event handlers on the viewer.

This is a workaround where we bind a click handler on a child element
instead, and catch and stop the event.
