### PR TITLE
Fix #49 - Centering broken if Bootstrap css loaded

### DIFF
--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -3,6 +3,13 @@
     position: relative;
 }
 
+/* prevent sizing issues from bootstrap (and others) that change global defaults */
+.crocodoc-viewer * {
+    -webkit-box-sizing: initial;
+    -moz-box-sizing: initial;
+    box-sizing: initial;
+}
+
 .crocodoc-viewer-fullscreen {
     background: #000;
     margin: 0;


### PR DESCRIPTION
Bootstrap applies a global `box-sizing: border-box`, which messes up page size calculations. This fix simply undoes Bootstrap's style.
