### PR TITLE
Add shortcut method to extend a layout

### DIFF
--- a/src/js/components/layout-base.js
+++ b/src/js/components/layout-base.js
@@ -865,6 +865,15 @@ Crocodoc.addComponent('layout-base', function (scope) {
         updateLayout: function () {},
         calculateZoomAutoValue: function () { return 1; },
         calculateNextPage: function () { return 1; },
-        calculatePreviousPage: function () { return 1; }
+        calculatePreviousPage: function () { return 1; },
+
+        /**
+         * Shortcut method to extend this layout
+         * @param   {Object} layout The layout mixins
+         * @returns {Object}        The extended layout
+         */
+        extend: function (layout) {
+            return util.extend({}, this, layout);
+        }
     };
 });

--- a/src/js/components/layout-horizontal.js
+++ b/src/js/components/layout-horizontal.js
@@ -21,7 +21,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_HORIZONTAL, ['layout-base'], f
     // Public
     //--------------------------------------------------------------------------
 
-    return util.extend({}, base, {
+    return base.extend({
 
         /**
          * Calculate the numeric value for zoom 'auto' for this layout mode

--- a/src/js/components/layout-presentation-two-page.js
+++ b/src/js/components/layout-presentation-two-page.js
@@ -20,7 +20,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_PRESENTATION_TWO_PAGE, ['layou
     // Public
     //--------------------------------------------------------------------------
 
-    return util.extend({}, presentation, {
+    return presentation.extend({
         /**
          * Initialize the presentation-two-page layout component
          * @returns {void}

--- a/src/js/components/layout-presentation.js
+++ b/src/js/components/layout-presentation.js
@@ -37,7 +37,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_PRESENTATION, ['layout-base'],
     // Public
     //--------------------------------------------------------------------------
 
-    return util.extend({}, base, {
+    return base.extend({
         /**
          * Initialize the presentation layout component
          * @returns {void}

--- a/src/js/components/layout-vertical.js
+++ b/src/js/components/layout-vertical.js
@@ -21,7 +21,7 @@ Crocodoc.addComponent('layout-' + Crocodoc.LAYOUT_VERTICAL, ['layout-base'], fun
     // Public
     //--------------------------------------------------------------------------
 
-    return util.extend({}, base, {
+    return base.extend({
 
         /**
          * Calculate the numeric value for zoom 'auto' for this layout mode

--- a/test/js/components/layout-horizontal-test.js
+++ b/test/js/components/layout-horizontal-test.js
@@ -13,7 +13,10 @@ module('Component - layout-horizontal', {
                 init: function () {},
                 handleResize: function () {},
                 handleScroll: function () {},
-                updateCurrentPage: function () {}
+                updateCurrentPage: function () {},
+                extend: function (obj) {
+                    return Crocodoc.getUtility('common').extend({}, this, obj);
+                }
             }
         };
         this.config = {

--- a/test/js/components/layout-presentation-test.js
+++ b/test/js/components/layout-presentation-test.js
@@ -14,7 +14,10 @@ module('Component - layout-presentation', {
                 init: function () {},
                 updateCurrentPage: function () {},
                 updatePageMargins: function () {},
-                updatePageClasses: function () {}
+                updatePageClasses: function () {},
+                extend: function (obj) {
+                    return Crocodoc.getUtility('common').extend({}, this, obj);
+                }
             }
         };
 

--- a/test/js/components/layout-presentation-two-page-test.js
+++ b/test/js/components/layout-presentation-two-page-test.js
@@ -11,7 +11,10 @@ module('Component - layout-presentation-two-page', {
             'layout-presentation': {
                 init: function () {},
                 calculatePreviousPage: function () {},
-                calculateNextPage: function () {}
+                calculateNextPage: function () {},
+                extend: function (obj) {
+                    return Crocodoc.getUtility('common').extend({}, this, obj);
+                }
             }
         };
 

--- a/test/js/components/layout-vertical-single-column-test.js
+++ b/test/js/components/layout-vertical-single-column-test.js
@@ -9,7 +9,10 @@ module('Component - layout-vertical-single-column', {
         this.scope = Crocodoc.getScopeForTest(this);
         this.mixins = {
             'layout-vertical': {
-                init: function () {}
+                init: function () {},
+                extend: function (obj) {
+                    return Crocodoc.getUtility('common').extend({}, this, obj);
+                }
             }
         };
 

--- a/test/js/components/layout-vertical-test.js
+++ b/test/js/components/layout-vertical-test.js
@@ -13,7 +13,10 @@ module('Component - layout-vertical', {
                 init: function () {},
                 handleResize: function () {},
                 handleScroll: function () {},
-                updateCurrentPage: function () {}
+                updateCurrentPage: function () {},
+                extend: function (obj) {
+                    return Crocodoc.getUtility('common').extend({}, this, obj);
+                }
             }
         };
         this.config = {


### PR DESCRIPTION
This avoids having to add `scope.getUtility('common').extend({}, base, { ... });` in layouts that use mixins to extend.
