### PR TITLE
Fix issue with optimistic asset prefetching in non-svg browsers

### DIFF
--- a/src/js/components/viewer-base.js
+++ b/src/js/components/viewer-base.js
@@ -498,6 +498,10 @@ Crocodoc.addComponent('viewer-base', function (scope) {
                 throw new Error('no URL given for viewer assets');
             }
 
+            if (browser.ielt9) {
+                config.enableTextSelection = false;
+            }
+
             // make the url absolute
             config.url = scope.getUtility('url').makeAbsolute(config.url);
 
@@ -590,7 +594,7 @@ Crocodoc.addComponent('viewer-base', function (scope) {
         loadAssets: function () {
             var $loadStylesheetPromise,
                 $loadMetadataPromise,
-                $pageOneSVGPromise,
+                $pageOneContentPromise,
                 $pageOneTextPromise;
 
             $loadMetadataPromise = scope.get('metadata');
@@ -616,7 +620,14 @@ Crocodoc.addComponent('viewer-base', function (scope) {
 
             // load page 1 assets immediately if necessary
             if (!config.pageStart || config.pageStart === 1) {
-                $pageOneSVGPromise = scope.get('page-svg', 1);
+                if (support.svg) {
+                    $pageOneContentPromise = scope.get('page-svg', 1);
+                } else if (config.conversionIsComplete) {
+                    // unfortunately, page-1.png is not necessarily available
+                    // on View API's document.viewable event, so we can only
+                    // prefetch page-1.png if conversion is complete
+                    $pageOneContentPromise = scope.get('page-img', 1);
+                }
                 if (config.enableTextSelection) {
                     $pageOneTextPromise = scope.get('page-text', 1);
                 }
@@ -633,8 +644,8 @@ Crocodoc.addComponent('viewer-base', function (scope) {
                     abort: function () {
                         $loadMetadataPromise.abort();
                         $loadStylesheetPromise.abort();
-                        if ($pageOneSVGPromise) {
-                            $pageOneSVGPromise.abort();
+                        if ($pageOneContentPromise) {
+                            $pageOneContentPromise.abort();
                         }
                         if ($pageOneTextPromise) {
                             $pageOneTextPromise.abort();


### PR DESCRIPTION
IE 8 would load page-svg and page-text assets for page 1, which is obviously unnecessary. This commit patches that bug and also enables page-1.png to be prefetched if conversion is complete. I also added better unit tests around the asset-fetching logic in viewer-base.
