### PR TITLE
LazyLader: only load visible pages initially

### DIFF
--- a/src/js/components/lazy-loader.js
+++ b/src/js/components/lazy-loader.js
@@ -22,18 +22,22 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
         pages,
         numPages,
         pagefocusTriggerLoadingTID,
+        readyTriggerLoadingTID,
         pageLoadTID,
         pageLoadQueue = [],
         pageLoadRange = 1,
         pageLoadingStopped = true,
         scrollDirection = 1,
+        ready = false,
         layoutState = {
             page: 1,
             visiblePages: [1]
         };
 
     var PAGE_LOAD_INTERVAL = (browser.mobile || browser.ielt10) ? 100 : 50, //ms between initiating page loads
-        MAX_PAGE_LOAD_RANGE = (browser.mobile || browser.ielt10) ? 8 : 32;
+        MAX_PAGE_LOAD_RANGE = (browser.mobile || browser.ielt10) ? 8 : 32,
+        // the delay in ms to wait before triggering preloading after `ready`
+        READY_TRIGGER_PRELOADING_DELAY = 1000;
 
     /**
      * Create and return a range object (eg., { min: x, max: y })
@@ -225,6 +229,7 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
             'beforezoom',
             'pageavailable',
             'pagefocus',
+            'ready',
             'scroll',
             'scrollend',
             'zoom'
@@ -247,11 +252,14 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
                 case 'pagefocus':
                     this.handlePageFocus(data);
                     break;
+                case 'ready':
+                    this.handleReady();
+                    break;
                 case 'scroll':
-                    this.handleScroll(data);
+                    this.handleScroll();
                     break;
                 case 'scrollend':
-                    this.handleScrollEnd(data);
+                    this.handleScrollEnd();
                     break;
                 case 'zoom':
                     this.handleZoom(data);
@@ -368,6 +376,7 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
          * @returns {void}
          */
         cancelAllLoading: function () {
+            clearTimeout(readyTriggerLoadingTID);
             clearTimeout(pagefocusTriggerLoadingTID);
             clearPageLoadQueue();
         },
@@ -411,11 +420,26 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
         },
 
         /**
+         * Handle ready messages
+         * @returns {void}
+         */
+        handleReady: function () {
+            ready = true;
+            this.loadVisiblePages();
+            readyTriggerLoadingTID = setTimeout(function () {
+                api.loadNecessaryPages();
+            }, READY_TRIGGER_PRELOADING_DELAY);
+        },
+
+        /**
          * Handle pageavailable messages
          * @param   {Object} data The message data
          * @returns {void}
          */
         handlePageAvailable: function (data) {
+            if (!ready) {
+                return;
+            }
             var i;
             if (data.all === true) {
                 data.upto = numPages;
@@ -435,7 +459,11 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
          * @returns {void}
          */
         handlePageFocus: function (data) {
+            // NOTE: update layout state before `ready`
             this.updateLayoutState(data);
+            if (!ready) {
+                return;
+            }
             this.cancelAllLoading();
             // set a timeout to trigger loading so we dont cause unnecessary layouts while scrolling
             pagefocusTriggerLoadingTID = setTimeout(function () {
@@ -449,6 +477,9 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
          * @returns {void}
          */
         handleBeforeZoom: function (data) {
+            if (!ready) {
+                return;
+            }
             this.cancelAllLoading();
             // @NOTE: for performance reasons, we unload as many pages as possible just before zooming
             // so we don't have to layout as many pages at a time immediately after the zoom.
@@ -463,7 +494,11 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
          * @returns {void}
          */
         handleZoom: function (data) {
+            // NOTE: update layout state before `ready`
             this.updateLayoutState(data);
+            if (!ready) {
+                return;
+            }
             this.loadNecessaryPages();
         },
 
@@ -482,6 +517,9 @@ Crocodoc.addComponent('lazy-loader', function (scope) {
          * @returns {void}
          */
         handleScrollEnd: function () {
+            if (!ready) {
+                return;
+            }
             this.loadNecessaryPages();
             this.unloadUnnecessaryPages(pageLoadRange);
         }

--- a/test/js/components/lazy-loader-test.js
+++ b/test/js/components/lazy-loader-test.js
@@ -211,9 +211,32 @@ test('loadVisiblePages() should queue all visible pages to load when called', fu
     }
 });
 
+test('handleReady() should load visible pages when called', function () {
+    this.component.init(this.pages);
+
+    this.mock(this.component)
+        .expects('loadVisiblePages');
+    this.component.handleReady();
+});
+
+test('handleReady() should load necessary pages after a timeout when called', function () {
+    this.clock = sinon.useFakeTimers();
+    this.component.init(this.pages);
+
+    this.mock(this.component)
+        .expects('loadNecessaryPages');
+    this.component.handleReady();
+    this.clock.tick(1000);
+    this.clock.restore();
+});
+
 test('handleZoom() should load necessary pages and update layout state when called', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var mock = this.mock(this.component),
         data = { page: 2, visiblePages: [2] };
+
     mock.expects('loadNecessaryPages');
     mock.expects('updateLayoutState').withArgs(data);
     this.component.handleZoom(data);
@@ -226,6 +249,9 @@ test('handleScroll() should call cancel page loading when called', function () {
 });
 
 test('handleScrollEnd() should load necessary pages and unload unnecessary ones when called', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var mock = this.mock(this.component);
     mock.expects('loadNecessaryPages');
     mock.expects('unloadUnnecessaryPages');
@@ -233,6 +259,9 @@ test('handleScrollEnd() should load necessary pages and unload unnecessary ones 
 });
 
 test('handlePageFocus() should call update the layout state, cancel any page loading, and then (eventually) load necessary pages when called', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var mock = this.mock(this.component);
     var data = { page: 1, visiblePages: [1] };
     mock.expects('updateLayoutState').withArgs(data);
@@ -251,6 +280,9 @@ test('unloadPage() should call page.unload() when called with a valid page index
 });
 
 test('handlePageAvailable() should queue the appropriate pages to load when called with data.page', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var page = 4;
     for (var i = 0; i < 10; i++) {
         this.pages.push(this.pageComponent);
@@ -263,6 +295,9 @@ test('handlePageAvailable() should queue the appropriate pages to load when call
 });
 
 test('handlePageAvailable() should queue the appropriate pages to load when called with data.upto', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var page = 3;
     for (var i = 0; i < 10; i++) {
         this.pages.push(this.pageComponent);
@@ -276,6 +311,9 @@ test('handlePageAvailable() should queue the appropriate pages to load when call
 });
 
 test('handlePageAvailable() should queue the appropriate pages to load when called with data.all', function () {
+    this.component.init(this.pages);
+    this.component.handleReady();
+
     var page = 3;
     for (var i = 0; i < 10; i++) {
         this.pages.push(this.pageComponent);


### PR DESCRIPTION
LazyLoader was loading `MAX_PAGE_LOAD_RANGE` pages as soon as the
first zoom happened, and this caused a slight delay in viewing the
first page. This commit amends that behavior to only load visible
pages when the viewer is ready, and sets a timeout to load the rest of
the "necessary" pages after about a second.
