### PR TITLE
Fix IE9 issue with box-sizing: initial

### DIFF
--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -5,9 +5,9 @@
 
 /* prevent sizing issues from bootstrap (and others) that change global defaults */
 .crocodoc-viewer * {
-    -webkit-box-sizing: initial;
-    -moz-box-sizing: initial;
-    box-sizing: initial;
+    -webkit-box-sizing: content-box !important;
+    -moz-box-sizing: content-box !important;
+    box-sizing: content-box !important;
 }
 
 .crocodoc-viewer-fullscreen {


### PR DESCRIPTION
IE9 (and maybe other versions of IE) apparently do not support
`box-sizing: initial`, and the initial (default) value must be
named explicitly as `box-sizing: content-box`.
