### PR TITLE
Fix errors caused by destroying a viewer while pages are loading

### DIFF
--- a/src/js/data-providers/page-svg.js
+++ b/src/js/data-providers/page-svg.js
@@ -13,6 +13,7 @@ Crocodoc.addDataProvider('page-svg', function(scope) {
         browser = scope.getUtility('browser'),
         subpx = scope.getUtility('subpx'),
         config = scope.getConfig(),
+        destroyed = false,
         cache = {};
 
     /**
@@ -47,6 +48,10 @@ Crocodoc.addDataProvider('page-svg', function(scope) {
      * @private
      */
     function processSVGContent(text) {
+        if (destroyed) {
+            return;
+        }
+
         var query = config.queryString.replace('&', '&#38;'),
             dataUrlCount;
 
@@ -95,7 +100,9 @@ Crocodoc.addDataProvider('page-svg', function(scope) {
             cache[pageNum] = $promise.then(processSVGContent).promise({
                 abort: function () {
                     $promise.abort();
-                    delete cache[pageNum];
+                    if (cache) {
+                        delete cache[pageNum];
+                    }
                 }
             });
             return cache[pageNum];
@@ -116,8 +123,8 @@ Crocodoc.addDataProvider('page-svg', function(scope) {
          * @returns {void}
          */
         destroy: function () {
-            util = ajax = subpx = browser = config = null;
-            cache = null;
+            destroyed = true;
+            util = ajax = subpx = browser = config = cache = null;
         }
     };
 });

--- a/src/js/data-providers/page-text.js
+++ b/src/js/data-providers/page-text.js
@@ -11,6 +11,7 @@ Crocodoc.addDataProvider('page-text', function(scope) {
     var util = scope.getUtility('common'),
         ajax = scope.getUtility('ajax'),
         config = scope.getConfig(),
+        destroyed = false,
         cache = {};
 
     /**
@@ -20,6 +21,10 @@ Crocodoc.addDataProvider('page-text', function(scope) {
      * @private
      */
     function processTextContent(text) {
+        if (destroyed) {
+            return;
+        }
+
         // in the text layer, divs are only used for text boxes, so
         // they should provide an accurate count
         var numTextBoxes = util.countInStr(text, '<div');
@@ -61,7 +66,9 @@ Crocodoc.addDataProvider('page-text', function(scope) {
             cache[pageNum] = $promise.then(processTextContent).promise({
                 abort: function () {
                     $promise.abort();
-                    delete cache[pageNum];
+                    if (cache) {
+                        delete cache[pageNum];
+                    }
                 }
             });
             return cache[pageNum];
@@ -82,8 +89,8 @@ Crocodoc.addDataProvider('page-text', function(scope) {
          * @returns {void}
          */
         destroy: function () {
-            util = ajax = config = null;
-            cache = null;
+            destroyed = true;
+            util = ajax = config = cache = null;
         }
     };
 });


### PR DESCRIPTION
Some errors were being thrown when promises were resolved after destroying a viewer (while pages were still loading). This fixes that issue.
