### PR TITLE
Add Crocodoc.getViewer()

### DIFF
--- a/src/js/core/crocodoc.js
+++ b/src/js/core/crocodoc.js
@@ -77,6 +77,15 @@ var Crocodoc = (function () {
         },
 
         /**
+         * Get a viewer instance by id
+         * @param {number} id   The id
+         * @returns {Object}    The viewer instance
+         */
+        getViewer: function (id) {
+            return Crocodoc.Viewer.get(id);
+        },
+
+        /**
          * Register a new component
          * @param  {string} name      The (unique) name of the component
          * @param  {Array} mixins     Array of component names to instantiate and pass as mixinable objects to the creator method

--- a/src/js/core/viewer.js
+++ b/src/js/core/viewer.js
@@ -13,7 +13,8 @@
     var CSS_CLASS_TEXT_DISABLED  = 'crocodoc-text-disabled',
         CSS_CLASS_LINKS_DISABLED = 'crocodoc-links-disabled';
 
-    var viewerInstanceCount = 0;
+    var viewerInstanceCount = 0,
+        instances = {};
 
     /**
      * Crocodoc.Viewer constructor
@@ -37,9 +38,11 @@
             throw new Error('Invalid container element');
         }
 
-        config.id = ++viewerInstanceCount;
+        this.id = config.id = ++viewerInstanceCount;
         config.api = this;
         config.$el = $el;
+        // register this instance
+        instances[this.id] = this;
 
         function init() {
             viewerBase.init();
@@ -54,6 +57,9 @@
          * @returns {void}
          */
         this.destroy = function () {
+            // unregister this instance
+            delete instances[config.id];
+
             // broadcast a destroy message
             scope.broadcast('destroy');
 
@@ -199,6 +205,15 @@
 
     Crocodoc.Viewer.prototype = new Crocodoc.EventTarget();
     Crocodoc.Viewer.prototype.constructor = Crocodoc.Viewer;
+
+    /**
+     * Get a viewer instance by id
+     * @param {number} id   The id
+     * @returns {Object}    The viewer instance
+     */
+    Crocodoc.Viewer.get = function (id) {
+        return instances[id];
+    };
 
     // Global defaults
     Crocodoc.Viewer.defaults = {

--- a/test/js/core/crocodoc-test.js
+++ b/test/js/core/crocodoc-test.js
@@ -71,6 +71,7 @@ module('Framework - createViewer', {
             }
         };
         this.viewerAPI = {
+            id: 3,
             init: function () {}
         };
         this.scopeStub = sinon.stub(Crocodoc, 'Scope').returns(this.scope);
@@ -89,4 +90,19 @@ test('createViewer() should return a new instance of Crocodoc.Viewer when called
         .returns(this.viewerAPI);
     var instance = Crocodoc.createViewer(el, options);
     ok(this.viewerAPI === instance, 'returned the viewer instance');
+});
+
+test('getViewer() should return the viewer instance when called with a valid id', function () {
+    var el = $(), options = {};
+
+    this.stub(Crocodoc, 'Viewer')
+        .withArgs(el, options)
+        .returns(this.viewerAPI);
+    this.stub(Crocodoc.Viewer, 'get')
+        .withArgs(this.viewerAPI.id)
+        .returns(this.viewerAPI);
+
+    var instance = Crocodoc.createViewer(el, options);
+
+    equal(Crocodoc.getViewer(instance.id), instance, 'should be the same viewer');
 });

--- a/test/js/core/viewer-test.js
+++ b/test/js/core/viewer-test.js
@@ -242,3 +242,17 @@ test('updateLayout() should force a layout update when called', function () {
 
     viewer.updateLayout();
 });
+
+test('Crocodoc.Viewer.get() should return the viewer instance when called with a valid id', function () {
+    var viewer = new Crocodoc.Viewer(this.$el, { url: 'someurl' });
+
+    equal(Crocodoc.Viewer.get(viewer.id), viewer, 'should be the same viewer');
+});
+
+test('destroy() should unregister the instance when called', function () {
+    var viewer = new Crocodoc.Viewer(this.$el, { url: 'someurl' });
+    viewer.destroy();
+
+    notEqual(Crocodoc.Viewer.get(viewer.id), viewer, 'should not be the same viewer');
+    ok(!Crocodoc.Viewer.get(viewer.id), 'should not exist');
+});


### PR DESCRIPTION
I often find it useful to be able to get a reference to a viewer object by id.
