### PR TITLE
Add support for requiring viewer.js with CommonJS syntax

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,6 @@
 /*global module*/
 /*jshint node: true*/
 
-var WRAPPER_HEADER = 'var Crocodoc = (function ($) {\n\n',
-    WRAPPER_FOOTER = '\n\nreturn Crocodoc;\n})(jQuery);';
-
 module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-jshint');
@@ -90,10 +87,8 @@ module.exports = function (grunt) {
                 banner: '/*! Crocodoc Viewer - v<%= pkg.version %> | (c) <%= grunt.template.today("yyyy") %> Box */\n\n',
             },
             js: {
-                // also use the jQuery wrapper for js files
                 options: {
-                    banner: '<%= concat.options.banner %>' + WRAPPER_HEADER,
-                    footer: WRAPPER_FOOTER
+                    banner: ''
                 },
                 src: [
                     'src/js/core/crocodoc.js',
@@ -120,6 +115,15 @@ module.exports = function (grunt) {
                     'src/css/theme.css'
                 ],
                 dest: 'build/crocodoc.viewer.css'
+            },
+            wrapjs: {
+                src: ['src/js/wrap.js'],
+                dest: 'build/crocodoc.viewer.js',
+                options: {
+                    process: function (content) {
+                        return content.replace('//__crocodoc_viewer__', grunt.file.read('build/crocodoc.viewer.js'));
+                    }
+                }
             }
         },
         jshint: {
@@ -152,7 +156,7 @@ module.exports = function (grunt) {
             }
         },
         copy: {
-            main: {
+            dist: {
                 files: [{
                     expand: true,
                     cwd: 'build/',
@@ -175,7 +179,7 @@ module.exports = function (grunt) {
     });
 
     var useLogo = !grunt.option('no-logo');
-    var defaultTasks = ['test', 'concat:js'];
+    var defaultTasks = ['test', 'concat:js', 'concat:wrapjs'];
     if (useLogo) {
         defaultTasks.push('concat:css', 'imageEmbed');
     } else {
@@ -193,5 +197,5 @@ module.exports = function (grunt) {
     grunt.registerTask('default', defaultTasks);
     grunt.registerTask('build', ['default', 'cssmin', 'uglify']);
     grunt.registerTask('serve', ['default', 'configureRewriteRules', 'parallel:examples']);
-    grunt.registerTask('release', ['build', 'copy']);
+    grunt.registerTask('release', ['build', 'copy:dist']);
 };

--- a/src/js/core/crocodoc.js
+++ b/src/js/core/crocodoc.js
@@ -3,7 +3,11 @@
  * @author lakenen
  */
 
-/*global Crocodoc:true*/
+/*jshint unused:false*/
+
+if (typeof $ === 'undefined') {
+    throw new Error('jQuery is required');
+}
 
 /**
  * The one global object for Crocodoc JavaScript.

--- a/src/js/wrap.js
+++ b/src/js/wrap.js
@@ -1,0 +1,19 @@
+(function (window) {
+    /*global jQuery*/
+    /*jshint unused:false, undef:false*/
+    'use strict';
+    window.Crocodoc = (function(fn) {
+        if (typeof exports === 'object') {
+            // nodejs / browserify - export a function that accepts a jquery impl
+            module.exports = fn;
+        } else {
+            // normal browser environment
+            return fn(jQuery);
+        }
+    }(function($) {
+
+//__crocodoc_viewer__
+
+        return Crocodoc;
+    }));
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
``` js
var $ = require('jquery');
var Crocodoc = require('viewer')($);
var viewer = Crocodoc.createViewer(/*...*/);
```
