### PR TITLE
Removing old layout reference when changing layout 

### DIFF
--- a/src/js/core/viewer.js
+++ b/src/js/core/viewer.js
@@ -82,6 +82,8 @@
          * @returns {void}
          */
         this.setLayout = function (mode) {
+            // removing old reference to prevent errors when handling layoutchange message
+            layout = null;
             layout = viewerBase.setLayout(mode);
         };
 


### PR DESCRIPTION
Avoid errors when handling the layoutchange event (fixes #118)
