### PR TITLE
Return current page when viewer is destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,8 @@ viewer.on('ready', function (event) {
     * `error` - the error message
     * `resource` - the url of the resource that failed to load
     * `status` - the http status code
-* `destroy` Triggered when the document viewer is purposely destroyed with the destroy method.
+* `destroy` Triggered when the document viewer is purposely destroyed with the destroy method. Event properties:
+    * `page` - the current page
 * `fail` Triggered if the document fails to load. Event properties:
     * `error` - the error details
 * `ready` Triggered as soon as a document becomes viewable. Event properties:

--- a/src/js/core/viewer.js
+++ b/src/js/core/viewer.js
@@ -30,6 +30,7 @@
         var layout,
             $el = $(el),
             config = util.extend(true, {}, Crocodoc.Viewer.defaults, options),
+            pageNum = config.index + 1,
             scope = new Crocodoc.Scope(config),
             viewerBase = scope.createComponent('viewer-base');
 
@@ -61,7 +62,7 @@
             delete instances[config.id];
 
             // broadcast a destroy message
-            scope.broadcast('destroy');
+            scope.broadcast('destroy', { page: pageNum });
 
             // destroy all components and plugins in this scope
             scope.destroy();

--- a/test/js/core/viewer-test.js
+++ b/test/js/core/viewer-test.js
@@ -85,11 +85,11 @@ test('load() should load assets when called', function () {
 
 test('destroy() should broadcast a destroy message when called', function () {
     this.stub(Crocodoc, 'Scope').returns(this.scope);
-    var viewer = new Crocodoc.Viewer('body', {});
+    var viewer = new Crocodoc.Viewer('body', { index: 0 });
 
     this.mock(this.scope)
         .expects('broadcast')
-        .withArgs('destroy');
+        .withArgs('destroy', { page: 1 });
 
     viewer.destroy();
 });


### PR DESCRIPTION
This allows you to access the current page when the viewer is destroyed. I'm open to an alternate implementation of the idea, but this broadcast message seemed to most fit the current pattern.
