### PR TITLE
Modify the subpx util to wrap around text layer instead of inside

### DIFF
--- a/src/js/utilities/subpx.js
+++ b/src/js/utilities/subpx.js
@@ -82,7 +82,7 @@ Crocodoc.addUtility('subpx', function (framework) {
             if (!subpixelRenderingIsSupported) {
                 if (document.body.style.zoom !== undefined) {
                     var $wrap = $('<div>').addClass(CSS_CLASS_SUBPX_FIX);
-                    $(el).children().wrapAll($wrap);
+                    $(el).wrap($wrap);
                 }
             }
             return el;


### PR DESCRIPTION
This is a bug fix for annotations, because text selection serializes
differently with/out the subpx layer when using .crocodoc-page-text as
the reference element.