### PR TITLE
Added crocodoc.viewer.css to "main" property in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "Nicholas Silva <nes@box.com>"
   ],
   "description": "A viewer for documents converted with the Box View API",
-  "main": "dist/crocodoc.viewer.js",
+  "main": ["dist/crocodoc.viewer.js", "dist/crocodoc.viewer.css"],
   "keywords": [
     "box",
     "box",


### PR DESCRIPTION
When installing in a project that uses wiredep (https://github.com/taptapship/wiredep), the crocodoc.viewer.js script tag is added automatically but the crocodoc.viewer.css isn't. 

This is easily fixed by adding the crocodoc.viewer.css to the "main" property of bower.json